### PR TITLE
feat: Configure project as a component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-# My Design System
+# Beta Builders Design System
 
 A personal collection of React components.
+
+## Versioning
+
+This library uses [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for version control. To release a new version, create a new tag and push it to the repository.
+
+```bash
+git tag v1.0.1
+git push origin v1.0.1
+```
 
 ## Installation
 
 This library is intended to be installed directly from a private GitHub repository.
 
-In your project's `package.json`, add the following to your dependencies, replacing `<github_user>/<repo_name>` with the actual repository path:
+In your project's `package.json`, add the following to your dependencies. You can specify a version by appending a tag to the repository URL (e.g., `#v1.0.1`).
 
 ```json
 "dependencies": {
-  "my-ds": "github:<github_user>/<repo_name>"
+  "beta-builders-design-system": "github:edgardamasceno-dev/beta-builders-design-system#v1.0.1"
 }
 ```
 
@@ -24,16 +33,16 @@ yarn install
 pnpm install
 ```
 
-## Setup
+## Styling
 
-To use the components, you need to import the library's stylesheet.
+This library is designed to inherit styles from your application. For this to work correctly, you'll need to configure your project to share its Tailwind and shadcn styles.
 
-1.  **Import the CSS:**
+1.  **Peer Dependencies:**
 
-    In your main application file (e.g., `main.tsx` or `App.tsx`), import the stylesheet:
+    Ensure that you have the following packages installed in your project. These are required for the components to function correctly.
 
-    ```tsx
-    import 'my-ds/dist/ds.css'
+    ```bash
+    npm install tailwind-merge clsx
     ```
 
 2.  **Configure Tailwind CSS:**
@@ -45,7 +54,7 @@ To use the components, you need to import the library's stylesheet.
     module.exports = {
       content: [
         './src/**/*.{js,ts,jsx,tsx}',
-        './node_modules/my-ds/dist/**/*.js', // Add this line
+        './node_modules/beta-builders-design-system/dist/**/*.js',
       ],
       theme: {
         extend: {},
@@ -54,12 +63,20 @@ To use the components, you need to import the library's stylesheet.
     }
     ```
 
+3.  **Import the Stylesheet:**
+
+    In your main application file (e.g., `main.tsx` or `App.tsx`), import the stylesheet:
+
+    ```tsx
+    import 'beta-builders-design-system/dist/index.css'
+    ```
+
 ## Usage
 
 Here's how to use the `CounterCard` component.
 
 ```tsx
-import { CounterCard } from 'my-ds';
+import { CounterCard } from 'beta-builders-design-system';
 
 function MyComponent() {
   return (

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "private": false,
   "version": "0.0.1",
   "type": "module",
-  "main": "./dist/ds.umd.js",
-  "module": "./dist/ds.es.js",
+  "main": "./dist/index.umd.js",
+  "module": "./dist/index.es.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/ds.es.js",
-      "require": "./dist/ds.umd.js"
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.umd.js"
     }
   },
   "files": [
@@ -47,12 +47,17 @@
     "globals": "^16.2.0",
     "postcss": "^8.5.6",
     "storybook": "^9.0.13",
-    "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^6.0.0",
     "vite-plugin-dts": "^3.9.1",
     "vite-tsconfig-paths": "^5.1.4"
+  },
+  "peerDependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^3.3.1",
+    "clsx": "^2.1.1"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: "class",
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
+    './src/components/**/*.{ts,tsx}',
+    './src/stories/**/*.{ts,tsx}',
   ],
   theme: {
     extend: {},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'ds',
-      fileName: 'ds',
+      fileName: 'index',
     },
     rollupOptions: {
       external: ['react', 'react-dom'],


### PR DESCRIPTION
This pull request transforms the project into a reusable component library, ready to be consumed from a private GitHub repository.

### Changes

- **Project Structure:**
  - Removed application-specific files (`App.tsx`, `main.tsx`, `index.html`).
  - The `dev` script in `package.json` now launches Storybook for a better development experience.

- **Build Configuration:**
  - Updated Vite configuration to output all generated files to a `dist` directory.
  - Renamed the output files to `index.js` and `index.css` for clarity.

- **Dependency Management:**
  - Moved `tailwind-merge` and `clsx` to `peerDependencies` to ensure style consistency with consuming applications.

- **Documentation:**
  - Rewrote the `README.md` to provide clear instructions on:
    - How to install the library from a private GitHub repository.
    - How to use Git tags for versioning.
    - How to configure a consuming application's `tailwind.config.js` to inherit styles.
    - How to use the `CounterCard` component.

### How to Test

1.  Follow the installation and setup instructions in the updated `README.md`.
2.  Import and use the `CounterCard` component in a test project.
3.  Verify that the component renders correctly and inherits styles from the test project.